### PR TITLE
customSyscalls may now specify plugin filepaths to load

### DIFF
--- a/DLL/UHC.h
+++ b/DLL/UHC.h
@@ -23,7 +23,8 @@ enum UHCTableName {
 	NoBigButtonBlds,
 	AttackTypeIcons,
 	TwoScoutCivs,
-	ExplorerUnits
+	ExplorerUnits,
+	Upls
 };
 
 enum UHCSyscallType {
@@ -110,6 +111,7 @@ public:
 	int BasePop, ExtraPop, DeckCardCount;
 	TArray<UHCSyscall> SyscallGroups[GROUP_COUNT];
 	TArray<UHCCheat> Cheats;
+	TArray<LPWSTR> UplFilepaths;
 	TArray<LPWSTR> Personalities;
 	TArray<LPWSTR> AsianCivNames;
 	TArray<LPWSTR> NativeCivNames;

--- a/DLL/UHC.inc
+++ b/DLL/UHC.inc
@@ -67,6 +67,8 @@ UHCInfo struct
 	SyscallGroups UHCSyscallGroup GROUP_COUNT dup (<>)
 	CheatCount dd ?
 	Cheats UHCCheatPtr ?	
+	UplFilepathCount dd ?
+	UplFilepaths dd ?
 	PersonalityCount dd ?
 	Personalities dd ?
 	AsianCivCount dd ?


### PR DESCRIPTION
The customSyscalls configuration option is extended by this patch to allow specifying which plugin filepaths to load, instead of forcing all .upl files in the current folder to always be loaded.

After these changes, customSyscalls is effectively a multi-value property which also allows no values.
With no values specified, it acts the same way as it did before - loads up every .upl file in current folder (backwards-compatible behavior). However, when some values are specified, only those plugins will be attempted to be loaded into the game. The specified values may make use the asterisk wildcard.
Example definition:
`customSyscalls UHCPluginESOC.upl`

Documentation update is not included in this PR, though I could deliver it.