### PR TITLE
Request high-performance NVIDIA/AMD GPU

### DIFF
--- a/DLL/UHC.cpp
+++ b/DLL/UHC.cpp
@@ -15,6 +15,16 @@ UHCPluginInfo pluginInfo = {
 	reinterpret_cast<void(*)(void*, const char*)>(0x007B4F03)
 };
 
+// request high-performance NVIDIA GPU
+extern "C" {
+	__declspec(dllexport) DWORD NvOptimusEnablement = 0x00000001;
+}
+
+// request high-performance AMD GPU
+extern "C" {
+	__declspec(dllexport) int AmdPowerXpressRequestHighPerformance = 1;
+}
+
 // override operator new and delete
 /*void* operator new(size_t size) {
 	auto _operator_new = reinterpret_cast<void* (__thiscall *)(int, size_t*)>(0x401234);


### PR DESCRIPTION
Introduces a new baseline feature into UHC; makes any UHC-patched game mod request high-end NVIDIA/AMD GPU on multi-GPU systems, such as is common in laptops. Without these directives present, the game is by default run on a low-performance integrated GPU on some systems, harming performance and potentially introducing graphical glitches.

A test of the implementation is pending, though essentially the same approach has already been deployed successfully for the ESOC Patch.